### PR TITLE
ci: move release to cyberuni workflows and npm trusted publishing

### DIFF
--- a/.changeset/tidy-pandas-shave.md
+++ b/.changeset/tidy-pandas-shave.md
@@ -1,0 +1,5 @@
+---
+'jest-watch-repeat': patch
+---
+
+Move the release pipeline to cyberuni's reusable workflows and npm trusted publishing (OIDC), and point package metadata at the new repository home.

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,9 +2,17 @@ name: pull-request
 on:
   pull_request:
     types: [opened, synchronize]
+  merge_group:
 
 jobs:
   code:
-    uses: unional/.github/.github/workflows/pnpm-verify.yml@main
+    uses: cyberuni/.github/.github/workflows/pnpm-verify.yml@main
     with:
       os: '["ubuntu-latest"]'
+      skip-playwright: true
+
+  publish-gate:
+    if: startsWith(github.head_ref, 'changeset-release/')
+    uses: cyberuni/.github/.github/workflows/pnpm-publish-gate.yml@main
+    permissions:
+      contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,15 +5,19 @@ on:
 
 jobs:
   code:
-    uses: unional/.github/.github/workflows/pnpm-verify.yml@main
+    uses: cyberuni/.github/.github/workflows/pnpm-verify.yml@main
     with:
       os: '["ubuntu-latest"]'
+      skip-playwright: true
 
   release:
-    uses: unional/.github/.github/workflows/pnpm-release-changeset.yml@main
+    uses: cyberuni/.github/.github/workflows/pnpm-release-changeset-oidc.yml@main
     needs: code
-    secrets: inherit
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
 
   # docgen:
-  #   uses: unional/.github/.github/workflows/pnpm-docs.yml@main
+  #   uses: cyberuni/.github/.github/workflows/pnpm-docs.yml@main
   #   needs: release

--- a/jest-watch-repeat/CHANGELOG.md
+++ b/jest-watch-repeat/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [2.0.0](https://github.com/unional/jest-watch-repeat/compare/v1.1.4...v2.0.0) (2019-11-27)
+# jest-watch-repeat
 
 ## 3.0.1
 
@@ -11,6 +11,8 @@
 ### Major Changes
 
 - 7b7ceaa: Update dependencies and `jest` to 29.
+
+## [2.0.0](https://github.com/unional/jest-watch-repeat/compare/v1.1.4...v2.0.0) (2019-11-27)
 
 ### Features
 

--- a/jest-watch-repeat/package.json
+++ b/jest-watch-repeat/package.json
@@ -8,13 +8,13 @@
     "testing",
     "tooling"
   ],
-  "homepage": "https://github.com/unional/jest-watch-repeat",
+  "homepage": "https://github.com/cyberuni/jest-watch-repeat",
   "bugs": {
-    "url": "https://github.com/unional/jest-watch-repeat/issues"
+    "url": "https://github.com/cyberuni/jest-watch-repeat/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/unional/jest-watch-repeat.git"
+    "url": "https://github.com/cyberuni/jest-watch-repeat.git"
   },
   "license": "MIT",
   "files": [

--- a/readme.md
+++ b/readme.md
@@ -56,12 +56,12 @@ Run only failed tests?
  (Y/N) > N
 ```
 
-[codecov-image]: https://codecov.io/gh/unional/jest-watch-repeat/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/unional/jest-watch-repeat
+[codecov-image]: https://codecov.io/gh/cyberuni/jest-watch-repeat/branch/main/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/cyberuni/jest-watch-repeat
 [downloads-image]: https://img.shields.io/npm/dm/jest-watch-repeat.svg?style=flat
 [downloads-url]: https://npmjs.org/package/jest-watch-repeat
-[github-action-url]: https://github.com/unional/jest-watch-repeat/actions
-[github-release]: https://github.com/unional/jest-watch-repeat/workflows/release/badge.svg
+[github-action-url]: https://github.com/cyberuni/jest-watch-repeat/actions
+[github-release]: https://github.com/cyberuni/jest-watch-repeat/workflows/release/badge.svg
 [npm-image]: https://img.shields.io/npm/v/jest-watch-repeat.svg?style=flat
 [npm-url]: https://npmjs.org/package/jest-watch-repeat
 [vscode-image]: https://img.shields.io/badge/vscode-ready-green.svg


### PR DESCRIPTION
Phase A of the repo-modernization sweep. **Do not merge yet** — this PR is written against the world *after* the repo is transferred to `cyberuni`, so it must land only once the transfer and the `npm trust` registration have happened (Phase B).

## What this changes

### Workflows — both jobs now point at cyberuni
- `pull-request.yml` and `release.yml` `code` jobs → `cyberuni/.github/.github/workflows/pnpm-verify.yml@main`, pinned to `os: '["ubuntu-latest"]'` and `skip-playwright: true` (no browser tests here). Codecov upload is left on — it feeds the README badge and gates nothing.
- `release.yml` `release` job → `cyberuni/.github/.github/workflows/pnpm-release-changeset-oidc.yml@main`, with an explicit `permissions:` block (`id-token` / `contents` / `pull-requests: write`) replacing `secrets: inherit`. Publishing moves from `NPM_TOKEN` + `CI_GITHUB_TOKEN` to npm trusted publishing (OIDC), which also emits SLSA provenance.
- `pull-request.yml` gains `merge_group:` (prerequisite for a merge queue once the repo is org-owned) and the `publish-gate` job, which inspects the tarball and runtime dependencies of the Version Packages PR before it can publish.
- `grep -rn "unional/.github" .github/workflows/` now returns nothing.

### Metadata
- `jest-watch-repeat/package.json` `homepage` / `bugs` / `repository` → `cyberuni/jest-watch-repeat`. The **npm package name is unchanged** — the scope does not follow the GitHub org.
- README badge links → `cyberuni`, and the codecov badge's stale `branch/master` corrected to `branch/main`.

### Changelog
`CHANGELOG.md` had a leftover semantic-release `# [2.0.0](…)` as its H1, so changesets — which inserts immediately after the first heading — had been filing `3.0.0` and `3.0.1` *underneath* the 2.0.0 header. Replaced with a `# jest-watch-repeat` H1 and restored 2.0.0 to its chronological position. Pre-existing; this stops the next release compounding it.

### Changeset
A deliberate `patch`. The change is repo-internal, but a changesets repo with no changeset produces a green release run that publishes nothing — and this repo needs one publish to prove OIDC works.

## Pre-existing state

**CI on `main` was green before this PR**, contrary to the sweep board, which listed this repo as red with `ELIFECYCLE` / a missing binary. Verified: the last `main` push run (2026-08-03) succeeded, and `pnpm install --frozen-lockfile && pnpm verify` passes clean on `main` today (16 tests, 100% coverage). The red runs on the board were all on Renovate branches with causes local to those bumps:

- `renovate/major-eslint-monorepo` (eslint v10) — `eslint` exits 2 because v10 requires flat config. That is the `ELIFECYCLE` the board saw; it is a lint failure, not a missing binary.
- `renovate/turbo-monorepo` — `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`, because Renovate regenerated the lockfile with entries younger than the 1440-minute soak in `.npmrc`. Ages out on its own.

So no CI fixes were needed here, and none are included.

## Settings applied outside this PR
- Baseline `main` ruleset created (requires `code / all-checks` only, plus deletion / non-fast-forward / CodeQL code scanning), **then** the legacy branch protection removed — `main` was never unprotected.
- Merge settings converged on the merge-commit baseline: merge commits on, squash and rebase off, auto-merge and update-branch on.
- Secret scanning and push protection enabled.
- `default_workflow_permissions` deliberately left at `write` — the `permissions:` block that makes `read` safe is in *this* unmerged PR.
- `can_approve_pull_request_reviews` was already `true`, and there is no `pull_request` review rule, so changesets can open the Version Packages PR.

## Not done, deliberately
- Not merged, no auto-merge armed, repo not transferred, no `npm trust` command run — all Phase B/C.
- `NPM_TOKEN` / `CI_GITHUB_TOKEN` left in place until a publish has proven OIDC works.
- Toolchain and dependency modernization (eslint → biome, the stuck Renovate majors) is out of Phase A scope.
- The long tail of abandoned greenkeeper/Snyk/Dependabot PRs left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)